### PR TITLE
Bugfix: Player should lose an extra HP only if Player attack equals KoS block …

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ while player_is_alive and kos_is_alive:
     kos_mod_message = get_mod_message(kos_mod)
 
     player_hp, kos_hp = clash(player_atk, player_blk, player_hp, kos_atk, kos_blk, kos_hp)
-    if player_atk == kos_blk and kos_mod == "Wolf" or kos_mod == "Star":
+    if player_atk == kos_blk and (kos_mod == "Wolf" or kos_mod == "Star"):
         player_hp -= 1
 
     player_is_alive = player_hp > 0


### PR DESCRIPTION
…*and* KoS mod is either Wolf or Star; code was allowing extra damage when only mod == Star was active.

This is because the order of operations regarding boolean evaluations was not properly applied. (See https://www.mathcs.emory.edu/~valerie/courses/fall10/155/resources/op_precedence.html)